### PR TITLE
Disable remote_autostart

### DIFF
--- a/7.0/00_xdebug.ini
+++ b/7.0/00_xdebug.ini
@@ -3,6 +3,6 @@ xdebug.default_enable = 0
 xdebug.remote_enable = 1
 xdebug.remote_handler = dbgp
 xdebug.remote_port = 9000
-xdebug.remote_autostart = 1
+xdebug.remote_autostart = 0
 xdebug.remote_connect_back = 1
 xdebug.max_nesting_level = 256


### PR DESCRIPTION
Do we really need to keep it started always?

> xdebug.remote_autostart
> Type: boolean, Default value: 0
> Normally you need to use a specific HTTP GET/POST variable to start remote debugging (see Remote Debugging). When this setting is set to 1, Xdebug will always attempt to start a remote debugging session and try to connect to a client, even if the GET/POST/COOKIE variable was not present.