### PR TITLE
Added "bcmath" PHP extension to both Dockerfiles.

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -70,6 +70,7 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         php5-xdebug@community \
         php5-xsl \
         php5-ldap \
+        php5-bcmath \
         && \
 
     # Install uploadprogress and imagick

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -67,6 +67,7 @@ RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/re
         php7-exif@community \
         php7-xsl@community \
         php7-ldap@community \
+        php7-bcmath@community \
         && \
 
     # Create symlinks for backward compatibility


### PR DESCRIPTION
This extension is required by Drupal Commerce 2.x (which is on top of Drupal 8) so it's installed properly. 
I particularly don't see a reason for not making it part of this image. It just make it more compatible.