### PR TITLE
Change max_input_vars from default value (1000) to 2000 in php.ini.

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -123,6 +123,7 @@ RUN sed -i \
         -e "s/^;date.timezone.*/date.timezone = UTC/" \
         -e "s/^memory_limit.*/memory_limit = -1/" \
         -e "s/^max_execution_time.*/max_execution_time = 300/" \
+        -e "s/^; max_input_vars.*/max_input_vars = 2000/" \
         -e "s/^post_max_size.*/post_max_size = 512M/" \
         -e "s/^upload_max_filesize.*/upload_max_filesize = 512M/" \
         -e "s/^;always_populate_raw_post_data.*/always_populate_raw_post_data = -1/" \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -131,6 +131,7 @@ RUN sed -i \
         -e "s/^;date.timezone.*/date.timezone = UTC/" \
         -e "s/^memory_limit.*/memory_limit = -1/" \
         -e "s/^max_execution_time.*/max_execution_time = 300/" \
+        -e "s/^; max_input_vars.*/max_input_vars = 2000/" \
         -e "s/^post_max_size.*/post_max_size = 512M/" \
         -e "s/^upload_max_filesize.*/upload_max_filesize = 512M/" \
         -e "s/^error_reporting.*/error_reporting = E_ALL/" \


### PR DESCRIPTION
The default value for the maximum number of input variables (1000) is a bit small for larger/more complex Drupal sites.