### PR TITLE
Update drush-launcher to version 0.5.1

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,7 +2,7 @@ ARG FROM_TAG
 
 FROM wodby/php:${FROM_TAG}
 
-ENV DRUSH_LAUNCHER_VER="0.4.3" \
+ENV DRUSH_LAUNCHER_VER="0.5.1" \
     \
     WODBY_DIR_FILES="/mnt/files" \
     WODBY_DIR_CONF="/var/www/conf" \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -2,7 +2,7 @@ ARG FROM_TAG
 
 FROM wodby/php:${FROM_TAG}
 
-ENV DRUSH_LAUNCHER_VER="0.4.3" \
+ENV DRUSH_LAUNCHER_VER="0.5.1" \
     \
     WODBY_DIR_FILES="/mnt/files" \
     WODBY_DIR_CONF="/var/www/conf" \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See [wodby/php](https://github.com/wodby/php) for the exact PHP version
 | -------------------------- | ------- | ------- | ------- | ------- |
 | [Drupal Console Launcher]  | latest  | latest  | -       | -       |
 | [Drush]                    | latest  | latest  | latest  | 7.4.0   |
-| [Drush Launcher]           | 0.4.3   | 0.4.3   | 0.4.3   | -       |
+| [Drush Launcher]           | 0.5.1   | 0.5.1   | 0.5.1   | -       |
 | [Drush Patchfile]          | latest  | latest  | latest  | latest  |
 | [Drush Registry Rebuild]   | 7.x     | 7.x     | 7.x     | 7.x     |
 


### PR DESCRIPTION
We improved Drupal 7 support in version 0.5.0 by adding support for a fallback via environment variables.