### PR TITLE
Update Dockerfile for php5.6 for Drupal 7 Drush

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -17,7 +17,7 @@ USER root
 
 RUN set -ex; \
     \
-    su-exec wodby composer global require drush/drush; \
+    su-exec wodby composer global require drush/drush:^8.0; \
     \
     # Drush launcher
     drush_launcher_url="https://github.com/drush-ops/drush-launcher/releases/download/${DRUSH_LAUNCHER_VER}/drush.phar"; \

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [wodby/php](https://github.com/wodby/php) for the exact PHP version
 | Tool                       | 7.1     | 7.0     | 5.6     | 
 | -------------------------- | ------- | ------- | ------- | 
 | [Drupal Console Launcher]  | latest  | latest  | -       | 
-| [Drush]                    | latest  | latest  | latest  | 
+| [Drush]                    | latest  | latest  | 8.x     | 
 | [Drush Launcher]           | 0.5.1   | 0.5.1   | 0.5.1   | 
 | [Drush Patchfile]          | latest  | latest  | latest  | 
 | [Drush Registry Rebuild]   | 7.x     | 7.x     | 7.x     | 


### PR DESCRIPTION
Limit php5.6 to Drush 8 for Drupal 7 compatibility.

http://docs.drush.org/en/master/install/