### PR TITLE
feat: allow passwordless redis

### DIFF
--- a/templates/drupal7.settings.php.tmpl
+++ b/templates/drupal7.settings.php.tmpl
@@ -32,7 +32,9 @@ $wodby['varnish']['version'] = '{{ getenv "VARNISH_VERSION" "4" }}';
 
 $wodby['redis']['host'] = '{{ getenv "REDIS_HOST" "" }}';
 $wodby['redis']['port'] = '{{ getenv "REDIS_PORT" "6379" }}';
-$wodby['redis']['password'] = '{{ getenv "REDIS_PASSWORD" "" }}';
+{{- if getenv "REDIS_PASSWORD" }}
+$wodby['redis']['password'] = '{{ getenv "REDIS_PASSWORD" }}';
+{{- end }}
 
 $conf['reverse_proxy_addresses'] = (function () {
     $internalSubnet = '172.17.0.0';
@@ -150,7 +152,9 @@ if (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'install') {
   if (!empty($wodby['redis']['host']) && $redis_module_path) {
     $conf['redis_client_host'] = $wodby['redis']['host'];
     $conf['redis_client_port'] = $wodby['redis']['port'];
-    $conf['redis_client_password'] = $wodby['redis']['password'];
+    if(isset($wodby['redis']['password'])) {
+      $conf['redis_client_password'] = $wodby['redis']['password'];
+    }
     $conf['redis_client_base'] = 0;
     $conf['redis_client_interface'] = 'PhpRedis';
     $conf['cache_backends'][] = "$redis_module_path/redis.autoload.inc";

--- a/templates/drupal8.settings.php.tmpl
+++ b/templates/drupal8.settings.php.tmpl
@@ -30,7 +30,9 @@ $wodby['db']['driver'] = '{{ getenv "DB_DRIVER" "mysql" }}';
 
 $wodby['redis']['host'] = '{{ getenv "REDIS_HOST" "" }}';
 $wodby['redis']['port'] = '{{ getenv "REDIS_PORT" "6379" }}';
-$wodby['redis']['password'] = '{{ getenv "REDIS_PASSWORD" "" }}';
+{{- if getenv "REDIS_PASSWORD" }}
+$wodby['redis']['password'] = '{{ getenv "REDIS_PASSWORD" }}';
+{{- end }}
 
 $wodby['solr_cloud']['password'] = '{{ getenv "SOLR_CLOUD_PASSWORD" }}';
 $wodby['solr_cloud']['server'] = '{{ getenv "SOLR_CLOUD_SERVER" "solr" }}';
@@ -150,7 +152,9 @@ if (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'install') {
   if (!empty($wodby['redis']['host']) && $redis_module_path) {
     $settings['redis.connection']['host'] = $wodby['redis']['host'];
     $settings['redis.connection']['port'] = $wodby['redis']['port'];
-    $settings['redis.connection']['password'] = $wodby['redis']['password'];
+    if(isset($wodby['redis']['password'])) {
+      $settings['redis.connection']['password'] = $wodby['redis']['password'];
+    }
     $settings['redis.connection']['base'] = 0;
     $settings['redis.connection']['interface'] = 'PhpRedis';
     $settings['cache']['default'] = 'cache.backend.redis';

--- a/templates/drupal9.settings.php.tmpl
+++ b/templates/drupal9.settings.php.tmpl
@@ -30,7 +30,9 @@ $wodby['db']['driver'] = '{{ getenv "DB_DRIVER" "mysql" }}';
 
 $wodby['redis']['host'] = '{{ getenv "REDIS_HOST" "" }}';
 $wodby['redis']['port'] = '{{ getenv "REDIS_PORT" "6379" }}';
-$wodby['redis']['password'] = '{{ getenv "REDIS_PASSWORD" "" }}';
+{{- if getenv "REDIS_PASSWORD" }}
+$wodby['redis']['password'] = '{{ getenv "REDIS_PASSWORD" }}';
+{{- end }}
 
 $wodby['solr_cloud']['password'] = '{{ getenv "SOLR_CLOUD_PASSWORD" }}';
 $wodby['solr_cloud']['server'] = '{{ getenv "SOLR_CLOUD_SERVER" "solr" }}';
@@ -144,7 +146,9 @@ if (!defined('MAINTENANCE_MODE') || MAINTENANCE_MODE != 'install') {
   if (!empty($wodby['redis']['host']) && $redis_module_path) {
     $settings['redis.connection']['host'] = $wodby['redis']['host'];
     $settings['redis.connection']['port'] = $wodby['redis']['port'];
-    $settings['redis.connection']['password'] = $wodby['redis']['password'];
+    if(isset($wodby['redis']['password'])) {
+      $settings['redis.connection']['password'] = $wodby['redis']['password'];
+    }
     $settings['redis.connection']['base'] = 0;
     $settings['redis.connection']['interface'] = 'PhpRedis';
     $settings['cache']['default'] = 'cache.backend.redis';


### PR DESCRIPTION
Currently if tht env variable `REDIS_PASSWORD` is empty or not provided the settings will lead to an exception because the `drupal/redis` module will check if the [password setting `isset()` instead of `empty()`](https://git.drupalcode.org/project/redis/-/blob/8.x-1.x/src/Client/PhpRedis.php#L35-37).

![image](https://user-images.githubusercontent.com/401819/203409922-dd6f1348-6d49-45a6-ba69-88e3b6719c3e.png)


With this PR the `password` setting is simply omitted when the env var is not provided.