### PR TITLE
feat: add support for setting a default php_storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PHP (FPM) for Drupal Docker Container Image 
+# PHP (FPM) for Drupal Docker Container Image
 
 [![Build Status](https://github.com/wodby/drupal-php/workflows/Build%20docker%20image/badge.svg)](https://github.com/wodby/drupal-php/actions)
 [![Docker Pulls](https://img.shields.io/docker/pulls/wodby/drupal-php.svg)](https://hub.docker.com/r/wodby/drupal-php)
@@ -6,13 +6,13 @@
 
 ## Docker Images
 
-❗For better reliability we release images with stability tags (`wodby/drupal-php:8-X.X.X`) which correspond to [git tags](https://github.com/wodby/drupal-php/releases). We strongly recommend using images only with stability tags. 
+❗For better reliability we release images with stability tags (`wodby/drupal-php:8-X.X.X`) which correspond to [git tags](https://github.com/wodby/drupal-php/releases). We strongly recommend using images only with stability tags.
 
 Overview:
 
 - All images based on Alpine Linux
 - Base image: [wodby/php](https://github.com/wodby/php)
-- [GitHub actions builds](https://github.com/wodby/drupal-php/actions) 
+- [GitHub actions builds](https://github.com/wodby/drupal-php/actions)
 - [Docker Hub](https://hub.docker.com/r/wodby/drupal-php)
 
 Supported tags and respective `Dockerxfile` links:
@@ -42,11 +42,12 @@ All images built for `linux/amd64` and `linux/arm64`
 
 ## Environment Variables
 
-| Variable                         | Default Value | Description |
-|----------------------------------|---------------|-------------|
-| `DRUPAL_REVERSE_PROXY_ADDRESSES` |               |             |
-| `PHP_OUTPUT_BUFFERING`           | `16384`       |             |
-| `PHP_REALPATH_CACHE_TTL`         | `3600`        |             |
+| Variable                         | Default Value | Description                                                     |
+|----------------------------------|---------------|-----------------------------------------------------------------|
+| `DRUPAL_REVERSE_PROXY_ADDRESSES` |               |                                                                 |
+| `DRUPAL_DRUPAL_PHP_STORAGE_DIR`  |               | Sets the default storage dir for generated PHP code (i.e. Twig) |
+| `PHP_OUTPUT_BUFFERING`           | `16384`       |                                                                 |
+| `PHP_REALPATH_CACHE_TTL`         | `3600`        |                                                                 |
 
 See [wodby/php](https://github.com/wodby/php) for all variables
 
@@ -55,20 +56,20 @@ See [wodby/php](https://github.com/wodby/php) for all variables
 Usage:
 ```
 make COMMAND [params ...]
- 
+
 commands:
     git-checkout target [ is_hash]
     drush-import source
-    init-drupal   
+    init-drupal
     cache-clear target
     cache-rebuild
     drush8-alias
     drush9-alias
     user-login
-    
+
 default params values:
     target all
-    is_hash 0 
+    is_hash 0
 ```
 
 See [wodby/php](https://github.com/wodby/php) for all actions

--- a/templates/drupal10.settings.php.tmpl
+++ b/templates/drupal10.settings.php.tmpl
@@ -9,6 +9,7 @@ $wodby['hosts'][] = '{{ . }}';
 {{ end }}{{ end }}
 
 $wodby['files_dir'] = '{{ getenv "FILES_DIR" }}';
+$wodby['php_storage_dir'] = '{{ getenv "DRUPAL_PHP_STORAGE_DIR" }}';
 $wodby['site'] = '{{ getenv "DRUPAL_SITE" }}';
 $wodby['hash_salt'] = '{{ getenv "DRUPAL_HASH_SALT" "" }}';
 $wodby['sync_salt'] = '{{ getenv "DRUPAL_FILES_SYNC_SALT" "" }}';
@@ -125,6 +126,10 @@ $settings['file_private_path'] = $wodby['files_dir'] . '/private';
 $settings['file_temp_path'] = '/tmp';
 
 $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+
+if (!empty($wodby['php_storage_dir'])) {
+  $settings['php_storage']['default']['directory'] = $wodby['php_storage_dir'];
+}
 
 if (!empty($wodby['hosts'])) {
   foreach ($wodby['hosts'] as $host) {

--- a/templates/drupal8.settings.php.tmpl
+++ b/templates/drupal8.settings.php.tmpl
@@ -9,6 +9,7 @@ $wodby['hosts'][] = '{{ . }}';
 {{ end }}{{ end }}
 
 $wodby['files_dir'] = '{{ getenv "FILES_DIR" }}';
+$wodby['php_storage_dir'] = '{{ getenv "DRUPAL_PHP_STORAGE_DIR" }}';
 $wodby['site'] = '{{ getenv "DRUPAL_SITE" }}';
 $wodby['hash_salt'] = '{{ getenv "DRUPAL_HASH_SALT" "" }}';
 $wodby['sync_salt'] = '{{ getenv "DRUPAL_FILES_SYNC_SALT" "" }}';
@@ -131,6 +132,10 @@ $config_directories['sync'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sy
 // For Drupal 8.8.0+
 // @see https://www.drupal.org/docs/8/configuration-management/changing-the-storage-location-of-the-sync-directory
 $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+
+if (!empty($wodby['php_storage_dir'])) {
+  $settings['php_storage']['default']['directory'] = $wodby['php_storage_dir'];
+}
 
 if (!empty($wodby['hosts'])) {
   foreach ($wodby['hosts'] as $host) {

--- a/templates/drupal9.settings.php.tmpl
+++ b/templates/drupal9.settings.php.tmpl
@@ -9,6 +9,7 @@ $wodby['hosts'][] = '{{ . }}';
 {{ end }}{{ end }}
 
 $wodby['files_dir'] = '{{ getenv "FILES_DIR" }}';
+$wodby['php_storage_dir'] = '{{ getenv "DRUPAL_PHP_STORAGE_DIR" }}';
 $wodby['site'] = '{{ getenv "DRUPAL_SITE" }}';
 $wodby['hash_salt'] = '{{ getenv "DRUPAL_HASH_SALT" "" }}';
 $wodby['sync_salt'] = '{{ getenv "DRUPAL_FILES_SYNC_SALT" "" }}';
@@ -125,6 +126,10 @@ $settings['file_private_path'] = $wodby['files_dir'] . '/private';
 $settings['file_temp_path'] = '/tmp';
 
 $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+
+if (!empty($wodby['php_storage_dir'])) {
+  $settings['php_storage']['default']['directory'] = $wodby['php_storage_dir'];
+}
 
 if (!empty($wodby['hosts'])) {
   foreach ($wodby['hosts'] as $host) {


### PR DESCRIPTION
## What

Adds a configurable environment variable to allow setting the default `php_storage` directory for generated PHP code.

## Why

Allows storing php generated code (i.e. twig)
- outside a directory typically part of backups
- outside of the Drupal `public://` directory (defuault)
- on an ephemeral fast storage (i.e. tmpfs)

## Additional information

- Separate twig cache by Aquia: https://docs.acquia.com/cloud-platform/manage/files/twig/
- `PhpStorageFactory`: https://git.drupalcode.org/project/drupal/-/blob/11.x/core/lib/Drupal/Core/PhpStorage/PhpStorageFactory.php#L37-39