### PR TITLE
feat: do not override config_sync_directory when already defined

### DIFF
--- a/templates/drupal10.settings.php.tmpl
+++ b/templates/drupal10.settings.php.tmpl
@@ -131,7 +131,7 @@ $settings['file_public_path'] = "sites/{$wodby['site']}/files";
 $settings['file_private_path'] = $wodby['files_dir'] . '/private';
 $settings['file_temp_path'] = '/tmp';
 
-if (empty($settings['config_sync_directory'])) {
+if (!empty($wodby['sync_salt']) && empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
 }
 

--- a/templates/drupal10.settings.php.tmpl
+++ b/templates/drupal10.settings.php.tmpl
@@ -131,7 +131,9 @@ $settings['file_public_path'] = "sites/{$wodby['site']}/files";
 $settings['file_private_path'] = $wodby['files_dir'] . '/private';
 $settings['file_temp_path'] = '/tmp';
 
-$settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+if (empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+}
 
 if (!empty($wodby['php_storage_dir'])) {
   $settings['php_storage']['default']['directory'] = $wodby['php_storage_dir'];

--- a/templates/drupal8.settings.php.tmpl
+++ b/templates/drupal8.settings.php.tmpl
@@ -134,10 +134,15 @@ $settings['file_temp_path'] = '/tmp';
 // Older versions
 $config['system.file']['path']['temporary'] = '/tmp';
 
-$config_directories['sync'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
-// For Drupal 8.8.0+
+// For Drupal < 8.8.0
 // @see https://www.drupal.org/docs/8/configuration-management/changing-the-storage-location-of-the-sync-directory
-$settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+if (empty($config_directories['sync'])) {
+  $config_directories['sync'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+}
+// For Drupal >= 8.8.0
+if (empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+}
 
 if (!empty($wodby['php_storage_dir'])) {
   $settings['php_storage']['default']['directory'] = $wodby['php_storage_dir'];

--- a/templates/drupal8.settings.php.tmpl
+++ b/templates/drupal8.settings.php.tmpl
@@ -136,11 +136,11 @@ $config['system.file']['path']['temporary'] = '/tmp';
 
 // For Drupal < 8.8.0
 // @see https://www.drupal.org/docs/8/configuration-management/changing-the-storage-location-of-the-sync-directory
-if (empty($config_directories['sync'])) {
+if (!empty($wodby['sync_salt']) && empty($config_directories['sync'])) {
   $config_directories['sync'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
 }
 // For Drupal >= 8.8.0
-if (empty($settings['config_sync_directory'])) {
+if (!empty($wodby['sync_salt']) && empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
 }
 

--- a/templates/drupal9.settings.php.tmpl
+++ b/templates/drupal9.settings.php.tmpl
@@ -131,7 +131,7 @@ $settings['file_public_path'] = "sites/{$wodby['site']}/files";
 $settings['file_private_path'] = $wodby['files_dir'] . '/private';
 $settings['file_temp_path'] = '/tmp';
 
-if (empty($settings['config_sync_directory'])) {
+if (!empty($wodby['sync_salt']) && empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
 }
 

--- a/templates/drupal9.settings.php.tmpl
+++ b/templates/drupal9.settings.php.tmpl
@@ -131,7 +131,9 @@ $settings['file_public_path'] = "sites/{$wodby['site']}/files";
 $settings['file_private_path'] = $wodby['files_dir'] . '/private';
 $settings['file_temp_path'] = '/tmp';
 
-$settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+if (empty($settings['config_sync_directory'])) {
+  $settings['config_sync_directory'] = $wodby['files_dir'] . '/config/sync_' . $wodby['sync_salt'];
+}
 
 if (!empty($wodby['php_storage_dir'])) {
   $settings['php_storage']['default']['directory'] = $wodby['php_storage_dir'];


### PR DESCRIPTION
## What

Ensure that the setting `config_sync_directory` isn't already set before configuring it.

## Why

* This aligns with other settings which are only configured if a value isn't already set.
* Ensures that no matter when wodby.settings.php is included it will not change it's behaviour
* Allows setting a custom location for config_sync_directory